### PR TITLE
NEW: Add the ability to not record prov for specified actions in pipelines

### DIFF
--- a/src/rachis/core/archive/__init__.py
+++ b/src/rachis/core/archive/__init__.py
@@ -7,9 +7,11 @@
 # ----------------------------------------------------------------------------
 
 from .provenance import (ImportProvenanceCapture, ActionProvenanceCapture,
-                         PipelineProvenanceCapture, ReportProvenanceCapture)
+                         PipelineProvenanceCapture, ReportProvenanceCapture,
+                         NoOpProvenanceCapture)
 from .archiver import Archiver
 
 
 __all__ = ['Archiver', 'ImportProvenanceCapture', 'ActionProvenanceCapture',
-           'PipelineProvenanceCapture', 'ReportProvenanceCapture']
+           'PipelineProvenanceCapture', 'ReportProvenanceCapture',
+           'NoOpProvenanceCapture']

--- a/src/rachis/core/archive/provenance.py
+++ b/src/rachis/core/archive/provenance.py
@@ -684,3 +684,63 @@ class ReportProvenanceCapture(ProvenanceCapture):
         action['inputs'] = self.inputs
 
         return action
+
+
+# TODO: Currently this is creating a metadata.yaml and a conda-env.yaml from
+# the archiver, and that's it. So the internal artifacts are in the returned
+# artifact's provenance/artifacts dir and just look like uuid/metadata.yaml +
+# conda-env.yaml
+class NoOpProvenanceCapture(ProvenanceCapture):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def add_ancestor(self, *args, **kwargs):
+        pass
+
+    def make_citation_key(self, *args, **kwargs):
+        pass
+
+    def make_software_entry(self, *args, **kwargs):
+        pass
+
+    def reference_plugin(self, *args, **kwargs):
+        pass
+
+    def capture_env(self, *args, **kwargs):
+        pass
+
+    def transformation_recorder(self, *args, **kwargs):
+        def recorder(*args, **kwargs):
+            pass
+
+        return recorder
+
+    def make_execution_section(self, *args, **kwargs):
+        pass
+
+    def make_transformers_section(self, *args, **kwargs):
+        pass
+
+    def make_env_section(self, *args, **kwargs):
+        pass
+
+    def write_action_yaml(self,*args, **kwargs):
+        pass
+
+    def write_citations_bib(self, *args, **kwargs):
+        pass
+
+    def finalize(self, *args, **kwargs):
+        pass
+
+    def fork(self, *args, **kwargs):
+        return NoOpProvenanceCapture()
+
+    def handle_metadata(self, *args, **kwargs):
+        pass
+
+    def add_parameter(self, *args, **kwargs):
+        pass
+
+    def add_input(self, *args, **kwargs):
+        pass

--- a/src/rachis/core/testing/pipeline.py
+++ b/src/rachis/core/testing/pipeline.py
@@ -28,9 +28,15 @@ def parameter_only_pipeline(ctx, int1, int2=2, metadata=None, other=False):
     return ints1, more_ints
 
 
-def typical_pipeline(ctx, int_sequence, mapping, do_extra_thing, add=1):
-    split_ints = ctx.get_action('dummy_plugin', 'split_ints')
-    most_common_viz = ctx.get_action('dummy_plugin', 'most_common_viz')
+def typical_pipeline(
+        ctx, int_sequence, mapping, do_extra_thing, add=1, record_prov=True
+    ):
+    split_ints = ctx.get_action(
+        'dummy_plugin', 'split_ints', record_prov=record_prov
+    )
+    most_common_viz = ctx.get_action(
+        'dummy_plugin', 'most_common_viz', record_prov=record_prov
+    )
 
     left, right = split_ints(int_sequence)
     if do_extra_thing:

--- a/src/rachis/core/testing/plugin.py
+++ b/src/rachis/core/testing/plugin.py
@@ -817,7 +817,8 @@ dummy_plugin.pipelines.register_function(
     },
     parameters={
         'do_extra_thing': Bool,
-        'add': Int
+        'add': Int,
+        'record_prov': Bool
     },
     outputs=[
         ('out_map', Mapping),
@@ -832,7 +833,8 @@ dummy_plugin.pipelines.register_function(
     },
     parameter_descriptions={
         'do_extra_thing': 'Increment `left` by `add` if true',
-        'add': 'Unused if `do_extra_thing` is false'
+        'add': 'Unused if `do_extra_thing` is false',
+        'record_prov': 'If True, record internal prov. If False, do not.'
     },
     output_descriptions={
         'out_map': 'Same as input',

--- a/src/rachis/plugin/context.py
+++ b/src/rachis/plugin/context.py
@@ -10,7 +10,7 @@ import abc
 
 class IContext(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def get_action(self, plugin: str, action: str):
+    def get_action(self, plugin: str, action: str, record_prov: bool=True):
         """Return a function matching the callable API of an action.
         This function is aware of the pipeline context and manages its own
         cleanup as appropriate.

--- a/src/rachis/sdk/action.py
+++ b/src/rachis/sdk/action.py
@@ -273,8 +273,11 @@ class Action(metaclass=abc.ABCMeta):
         """
         def bound_callable(*args, **kwargs):
             ctx = context_factory()
-            provenance = self._ProvCaptureCls(
-                self.type, self.plugin_id, self.id, execution_ctx)
+            if ctx.record_prov:
+                provenance = self._ProvCaptureCls(
+                    self.type, self.plugin_id, self.id, execution_ctx)
+            else:
+                provenance = archive.NoOpProvenanceCapture()
 
             if self.deprecated:
                 with rachis.core.util.warning() as warn:

--- a/src/rachis/sdk/context/base.py
+++ b/src/rachis/sdk/context/base.py
@@ -30,7 +30,9 @@ def _validate_collection(collection_order):
 
 
 class Context(IContext):
-    def __init__(self, action_obj=None, parent=None):
+    def __init__(self, action_obj=None, parent=None, record_prov=True):
+        self.record_prov = record_prov
+
         if parent is not None:
             self.cache = parent.cache
         else:
@@ -124,7 +126,7 @@ class Context(IContext):
         return rachis.sdk.Results(
             loaded_outputs.keys(), loaded_outputs.values())
 
-    def get_action(self, plugin: str, action: str):
+    def get_action(self, plugin: str, action: str, record_prov: bool=True):
         """Return a function matching the callable API of an action.
         This function is aware of the pipeline context and manages its own
         cleanup as appropriate.
@@ -145,7 +147,9 @@ class Context(IContext):
                 % (action, plugin))
 
         # Create a context for the new action
-        child_context = self.__class__(new_action_obj, parent=self)
+        child_context = self.__class__(
+            new_action_obj, parent=self, record_prov=record_prov
+        )
 
         # Return a callable for the new action
         callable_action = child_context.action_obj._rewrite_wrapper_signature(
@@ -188,3 +192,8 @@ class Context(IContext):
 
         # Return an artifact backed by the data in the cache
         return new_ref
+
+    # PROV TODO: Another option for prov is to capture it and then drop it at
+    # the end of the pipeline
+    def drop_inner_provenance(self, result, provenance):
+        pass

--- a/src/rachis/sdk/context/base.py
+++ b/src/rachis/sdk/context/base.py
@@ -175,7 +175,7 @@ class Context(IContext):
     # in the named cache in the end. We only have the pipeline alias in the
     # process pool
     def add_reference(self, ref):
-        """Add a reference to something destructable that will be owned by the
+        """Add a reference to something destructible that will be owned by the
            parent scope. The reason it needs to be tracked is so that on
            failure, a context can still identify what will (no longer) be
            returned.

--- a/src/rachis/sdk/context/parallel.py
+++ b/src/rachis/sdk/context/parallel.py
@@ -67,8 +67,10 @@ def _contains_proxies(*args, **kwargs):
 
 
 class ParallelContext(Context):
-    def __init__(self, action_obj, parent=None):
-        super(ParallelContext, self).__init__(action_obj, parent=parent)
+    def __init__(self, action_obj, parent=None, record_prov=True):
+        super(ParallelContext, self).__init__(
+            action_obj, parent=parent, record_prov=record_prov
+        )
 
         if parent is not None:
             self.action_executor_mapping = parent.action_executor_mapping

--- a/src/rachis/sdk/result.py
+++ b/src/rachis/sdk/result.py
@@ -450,6 +450,7 @@ class Artifact(Result):
             validation_object(data=result, level=validate_level)
 
         artifact = cls.__new__(cls)
+
         artifact._archiver = archive.Archiver.from_data(
             type, output_dir_fmt,
             data_initializer=result.path._move_or_copy,

--- a/src/rachis/sdk/tests/test_pipeline.py
+++ b/src/rachis/sdk/tests/test_pipeline.py
@@ -69,7 +69,9 @@ class TestPipeline(unittest.TestCase):
             ('do_extra_thing', inspect.Parameter(
                 'do_extra_thing', kind, annotation=Bool)),
             ('add', inspect.Parameter(
-                'add', kind, default=1, annotation=Int))
+                'add', kind, default=1, annotation=Int)),
+            ('record_prov', inspect.Parameter(
+                'record_prov', kind, default=True, annotation=Bool))
         ]
 
         for callable_attr in '__call__', 'asynchronous':

--- a/src/rachis/sdk/tests/test_pipeline.py
+++ b/src/rachis/sdk/tests/test_pipeline.py
@@ -248,6 +248,29 @@ class TestPipeline(unittest.TestCase):
                 m = rachis.Artifact.import_data(Mapping, {'a': 1})
                 call(self.int_sequence, m, False)
 
+    # TODO: Right now this test just asserts things don't crash, not that
+    # any specific desirable behavior is happening
+    def test_typical_pipeline_record_no_inner_prov(self):
+        for call in self.iter_callables('typical_pipeline'):
+            results = call(
+                self.int_sequence, self.mapping, False, record_prov=False
+            )
+
+            self.assertEqual(results.left_viz.type, Visualization)
+            self.assertEqual(results.left.view(list), [1])
+            self.assertEqual(results.right.view(list), [2, 3])
+            self.assertNotEqual(results.out_map.uuid, self.mapping.uuid)
+            self.assertEqual(results.out_map.view(dict),
+                             self.mapping.view(dict))
+
+            results = call(self.int_sequence, self.mapping, True, add=5)
+            self.assertEqual(results.left.view(list), [6])
+            self.assertEqual(results.right.view(list), [2, 3])
+
+            with self.assertRaisesRegex(ValueError, 'Bad mapping'):
+                m = rachis.Artifact.import_data(Mapping, {'a': 1})
+                call(self.int_sequence, m, False)
+
     def test_optional_artifact_pipeline(self):
         for call in self.iter_callables('optional_artifact_pipeline'):
             ints, = call(self.int_sequence)


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
Add the `record_prov` flag to `Context.get_action` and the `NoOpProvenanceCapture` allowing for specific provenance to not be recorded.

Closes #963   


# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
